### PR TITLE
add topdown vue and make objects visible

### DIFF
--- a/Joueur.js
+++ b/Joueur.js
@@ -1,3 +1,7 @@
+var vueTopDown = false;
+var cameraAvantTopDown = null;
+var angleCameraAvantTopDown = 0;
+
 function initJoueur() {
         var joueur = creerCamera();
         setPositionsCameraXYZ([15, 1, 15], joueur);
@@ -11,6 +15,32 @@ function initJoueur() {
 function enfoncerTouche(event) {
     if (!event) return;
     event.preventDefault();
+
+    // Page Up — entrer en vue de dessus
+    if (event.keyCode === 33) {
+        if (!vueTopDown) {
+            vueTopDown = true;
+            cameraAvantTopDown = joueur.slice();
+            angleCameraAvantTopDown = angleCamera;
+            setPositionsCameraXYZ([15, 40, 15], joueur);
+            setCiblesCameraXYZ([15, 0, 15], joueur);
+            setOrientationsXYZ([0, 0, -1], joueur);
+        }
+        return;
+    }
+
+    // Page Down — quitter la vue de dessus
+    if (event.keyCode === 34) {
+        if (vueTopDown) {
+            vueTopDown = false;
+            joueur.splice(0, 9,
+                cameraAvantTopDown[0], cameraAvantTopDown[1], cameraAvantTopDown[2],
+                cameraAvantTopDown[3], cameraAvantTopDown[4], cameraAvantTopDown[5],
+                cameraAvantTopDown[6], cameraAvantTopDown[7], cameraAvantTopDown[8]);
+            angleCamera = angleCameraAvantTopDown;
+        }
+        return;
+    }
 
     touchesActives[event.keyCode] = true;
 
@@ -60,6 +90,8 @@ function verifierCollisionTransporteur() {
 
     
 function miseAJourPositionJoueur() {
+    if (vueTopDown) return;
+
     var vitesse = joueur.vitesse;
     var vitesseRotation = joueur.vitesseRotation;
     camera = objScene3D.camera;
@@ -97,4 +129,6 @@ function miseAJourPositionJoueur() {
 
     //console.log("Position de la caméra : " + getPositionsCameraXYZ(joueur));
     //console.log("Angle : " + angleCamera);
+
 }
+

--- a/Scene.js
+++ b/Scene.js
@@ -26,6 +26,7 @@ async function initScene3D(objgl) {
     
     // Initialiser le trésor
     initTresor(objgl);
+    tresorObj.estSpecial = true;
     tabObjets3D.push(tresorObj);
 
     // Initialiser les flèches
@@ -46,6 +47,7 @@ async function initScene3D(objgl) {
         mat4.translate(objet3D.matModele, getPositionsXYZ(objet3D.transformations));
         mat4.scale(objet3D.matModele, getEchellesXYZ(objet3D.transformations));
         mat4.rotateY(objet3D.matModele, getAngleY(objet3D.transformations) * Math.PI / 180);
+        objet3D.estSpecial = true;
         tabObjets3D.push(objet3D);
     };
     
@@ -64,6 +66,7 @@ async function initScene3D(objgl) {
             mat4.translate(transporteur.matModele, getPositionsXYZ(transporteur.transformations));
             mat4.scale(transporteur.matModele, getEchellesXYZ(transporteur.transformations));
             mat4.rotateX(transporteur.matModele, getAngleX(transporteur.transformations) * Math.PI / 180);
+            transporteur.estSpecial = true;
             tabObjets3D.push(transporteur);
         }
 
@@ -82,6 +85,7 @@ async function initScene3D(objgl) {
             mat4.rotateX(recepteur.matModele, getAngleX(recepteur.transformations) * Math.PI / 180);
 
             positionsRecepteurs.push(positionRecepteur);
+            recepteur.estSpecial = true;
             tabObjets3D.push(recepteur);
         }
     }

--- a/index.htm
+++ b/index.htm
@@ -82,6 +82,8 @@
           var matModeleVue = mat4.create();
 
           for (var i = 0; i < objScene3D.tabObjets3D.length; i++) {
+              if (objScene3D.tabObjets3D[i].binVisible === false) continue;
+              if (vueTopDown && objScene3D.tabObjets3D[i].estSpecial && !touchesActives[67]) continue;
               var vertex = objScene3D.tabObjets3D[i].vertex;
               var couleurs = objScene3D.tabObjets3D[i].couleurs;
               var maillage = objScene3D.tabObjets3D[i].maillage;


### PR DESCRIPTION
Added topdown mode on "Page Up", pressing "Page down" returns camera to previous position before top down vue

When the player holds C, special objects (treasure, teleporters, arrows) become visible. Once the key is released, they become invisible again.